### PR TITLE
All leelaz params in config

### DIFF
--- a/training/tf-othello/auto-leela.py
+++ b/training/tf-othello/auto-leela.py
@@ -69,13 +69,14 @@ for file in os.listdir(directory):
         max_num = current_number
 max_num+=1
 
-for i in range(max_num, max_num+games_per_generation):
+for i in range(max_num, max_num + games_per_generation):
     # Start the subprocess
     print(f'Running game number {i}')
     p = subprocess.Popen(
-        [leelaz, '-v', '150', '-r5', '--noponder', '-q', '-m10', '-n', '-w', network],
+        [leelaz, '-w', network] + leelaz_args,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
+        bufsize=1,
         text=True
     )
     skip_credentials(p)
@@ -143,20 +144,22 @@ for i in range(max_num, max_num+games_per_generation):
     print("Winner: "+ (winner))
     assert winner == 'w' or winner == 'b'
 
+    # Prints the sgf file of the match
+    command = f'printsgf {i}_al.sgf\n'
+    p.stdin.write(command)
+    p.stdin.flush()
+
     # Send the dump_training command
     command = f'dump_training {winner} tmp{i}\n'
     #print(command)
     p.stdin.write(command)
     p.stdin.flush()
 
-    # Prints the sgf file of the match
-    command = f'printsgf {i}_al.sgf\n'
-    p.stdin.write(command)
-    p.stdin.flush()
-
     # Quit Leela Zero
     p.stdin.write('quit\n')
     p.stdin.flush()
+
+    time.sleep(0.5)
 
     # Edits the SGF
     sgf_edit(f"{i}_al.sgf", num_moves)

--- a/training/tf-othello/config.py
+++ b/training/tf-othello/config.py
@@ -6,6 +6,28 @@
 
 # Number of iterations for auto-leela
 games_per_generation = 2500
+max_parallel         = 4
+training_window      = 5
+visits               = 150
+random_moves         = 10
+resign_pct           = 5
+# puct                 = 0.5
+# logpuct              = 0.015
+# logconst             = 1.7
+# softmax_temp         = 1.0
+# fpu_reduction        = 0.25
+# ci_alpha             = 1e-5f
+
+leelaz_args = ['-v', str(visits),
+               '-r', str(resign_pct),
+               '-m', str(random_moves),
+               # '--puct', str(puct),
+               # '--logpuct', str(logpuct),
+               # '--logconst', str(logconst),
+               # '--softmax_temp', str(softmax_temp),
+               # '--fpu_reduction', str(fpu_reduction),
+               # '--ci_alpha' , str(ci_alpha),
+               '--noponder', '-n', '-q']
 
 # Path to LZO - general directory
 LZO = "/media/heathcliff/LZO"


### PR DESCRIPTION
1. There are several parameters that can be tuned in leela-zero.  They can be exposed by compiling leelaz with the flag USE_TUNER.

   The parameters are now available in the config file.

2. On some computers, the function to edit sgf would not find the file because of timing problems.  We added a small pause and exchanged the order of printsgf and dump_training commands.